### PR TITLE
osMaxPos rounding to digit parameter

### DIFF
--- a/R/osFUNs.R
+++ b/R/osFUNs.R
@@ -136,7 +136,7 @@ getPosLimit <- function(portfolio, symbol, timestamp){
 #' @export
 #' @note 
 #' TODO integrate orderqty='all' into osMaxPos for non-risk exit orders by combining side and pos for exits
-osMaxPos <- function(data, timestamp, orderqty, ordertype, orderside, portfolio, symbol, ruletype, ...){
+osMaxPos <- function(data, timestamp, orderqty, ordertype, orderside, portfolio, symbol, ruletype, digits=0, ...){
 	# check for current position
     pos<-getPosQty(portfolio,symbol,timestamp)
     # check against max position
@@ -177,7 +177,7 @@ osMaxPos <- function(data, timestamp, orderqty, ordertype, orderside, portfolio,
 	# buy long
     if(orderqty>0 && orderside=='long') {
         # note no round lots for max clip
-        clip <- round(PosLimit[,"MaxPos"] / PosLimit[,"LongLevels"], 0)
+        clip <- round(PosLimit[,"MaxPos"] / PosLimit[,"LongLevels"], digits)
 
         if ((orderqty+pos) > PosLimit[,"MaxPos"]) {
             # this order would put us beyond the MaxPos limit
@@ -203,7 +203,7 @@ osMaxPos <- function(data, timestamp, orderqty, ordertype, orderside, portfolio,
     #sell short
     if(orderqty<0 && orderside=='short') {
         # note no round lots for max clip
-        clip <- round(PosLimit[,"MinPos"] / PosLimit[,"ShortLevels"], 0)
+        clip <- round(PosLimit[,"MinPos"] / PosLimit[,"ShortLevels"], digits)
 
         if ((orderqty+pos) < PosLimit[,"MinPos"]) {
             # this order would put us beyond the MinPos limit

--- a/man/osMaxPos.Rd
+++ b/man/osMaxPos.Rd
@@ -24,6 +24,8 @@ osMaxPos(data, timestamp, orderqty, ordertype, orderside, portfolio, symbol,
 
 \item{ruletype}{one of "risk","order","rebalance","exit","enter", see \code{\link{add.rule}}}
 
+\item{digits}{numeric number of digits to round position size to}
+
 \item{...}{any other passthru parameters}
 }
 \description{


### PR DESCRIPTION
osMaxPos() always rounds position sizes to 0. Other functions will
allow a digits argument to control rounding (rulePctEquity). Added
digits argument defaulting to 0.

man/osMaxPos.Rd:
Updated documentation for new digits parameter.