### PR TITLE
Consistency in applyStrategy.rebalancing and rulePctEquity

### DIFF
--- a/R/applyStrategy.rebalancing.R
+++ b/R/applyStrategy.rebalancing.R
@@ -159,6 +159,7 @@ applyStrategy.rebalancing <- function(strategy ,
                                  indicators=sret$indicators, 
                                  signals=sret$signals, 
                                  parameters=parameters,  
+                                 verbose=verbose,
                                  ..., 
                                  path.dep=TRUE)
                     )

--- a/R/rebalance.rules.R
+++ b/R/rebalance.rules.R
@@ -44,13 +44,19 @@ rulePctEquity <- function (trade.percent=.02,
                            digits=NULL,
                            refprice=NULL,
                            portfolio,
+                           account=NULL,
                            symbol,
                            timestamp)
 {
     dummy <- updatePortf(Portfolio=portfolio,
             Dates=paste('::',timestamp,sep=''))
     trading.pl <- sum(.getPortfolio(portfolio)$summary$Net.Trading.PL)
-    total.equity <- initEq+trading.pl
+    if(!is.null(account)){
+      init.eq <- attributes(get(paste0('account.', account), .blotter))$initEq
+    } else {
+      init.eq <- initEq
+    }
+    total.equity <- init.eq+trading.pl
     tradeSize <- total.equity * trade.percent
     if(length(refprice)>1) refprice <- refprice[,1]
     if(!is.null(refprice)) tradeSize <- tradeSize/refprice

--- a/man/rulePctEquity.Rd
+++ b/man/rulePctEquity.Rd
@@ -20,6 +20,8 @@ rulePctEquity(trade.percent = 0.02, ..., longlevels = 1, shortlevels = 1,
 
 \item{portfolio}{text name of the portfolio to place orders in, typically set automatically}
 
+\item{account}{text name of the account to fetch initial equity from, defaults to initEq in the search path.}
+
 \item{symbol}{identifier of the instrument to cancel orders for, typically set automatically}
 
 \item{timestamp}{timestamp coercible to POSIXct that will be the time the order will be inserted on, typically set automatically}


### PR DESCRIPTION
R/applyStrategy.rebalancing:
verbose parameter was not passed to applyRules(). Would spit out txs
even when verbose was set to false. Now does not.

R/rebalance.rules.R:
rulePctEquity() depends on an initEq defined in the search path. Does not
specify it does in documentation. Made optional account parameter and now
rulePctEquity will find the initEq defined for the account, otherwise
will still use globally defined initEq. Is now consistent with
ruleWeights().

man/rulePctEquity.Rd:
Documenting new account parameter for rulePctEquity().