### PR TITLE
Fixed bug where if trailstop order is triggered it would sell [buy] at the high [low] of a bar.

### DIFF
--- a/R/ruleOrderProc.R
+++ b/R/ruleOrderProc.R
@@ -377,7 +377,7 @@ ruleOrderProc <- function(portfolio, symbol, mktdata, timestamp=NULL, ordertype=
                                         symbol=symbol,
                                         timestamp=timestamp,
                                         qty=order.qty,
-                                        price=new.order.price - order.threshold,
+                                        price=new.order.price,
                                         ordertype=orderType,
                                         side=order.side,
                                         threshold=order.threshold,


### PR DESCRIPTION
Previously:
at line 376 a new order replaces the previous trailstop order with order price
`new.order.price - order.threshold`
since the order is being replaced, we can say
`new.order.price != orderPrice`
and in the long case, this means
`new.order.price = previous_bar_high + order.threshold`
therefore, the new order price on line 380 is:
```
price = new.order.price - order.threshold
      = previous_bar_high + order.threshold - order.threshold
      = previous_bar_high
```
Since, in the long case, the next bar is most likely under
the high of the previous bar, the order is fired and you sell
the top of the previous bar.
analogous for the short case.

So, the order.threshold subtraction on line 380 was removed, since
the threshold is already considered in line 366 and 368.