### PR TITLE
clone.orderbook does not strip history

### DIFF
--- a/R/paramsets.R
+++ b/R/paramsets.R
@@ -72,15 +72,14 @@ clone.orderbook <- function(portfolio.st, cloned.portfolio.st, strip.history=TRU
     #must.have.args(match.call(), c('portfolio.st', 'cloned.portfolio.st'))
 
     orderbook <- getOrderBook(portfolio.st)
-
-    i <- 1  # TODO: find index number by name
-    names(orderbook)[i] <- cloned.portfolio.st
+    names(orderbook) <- cloned.portfolio.st
 
     if(strip.history == TRUE)
     {
-        for(symbol in names(orderbook[[portfolio.st]]))
-            orderbook[[portfolio.st]][[symbol]] <- orderbook[[portfolio.st]][[symbol]][1,]
-    }
+        symbols <- names(orderbook[[cloned.portfolio.st]])
+        for(symbol in symbols)
+            orderbook[[cloned.portfolio.st]][symbol]  <- list(NULL)
+    } 
 
     put.orderbook(cloned.portfolio.st, orderbook)
 }


### PR DESCRIPTION
The clone.orderbook function in paramsets.R does not actually strip history:

The old orderbook is assigned a new name 'cloned.portfolio.st', but the for loop continues to reference the old name, effectively voiding the strip.history = TRUE. Also, by keeping the first order with [1, ] one could potential pass an undesired open order to an attempted set of parameters, "<- list(NULL) solves this issue".

````
library(quantstrat)

quantstrat:::clone.orderbook
function (portfolio.st, cloned.portfolio.st, strip.history = TRUE) 
{
    orderbook <- getOrderBook(portfolio.st)
    i <- 1
    names(orderbook)[i] <- cloned.portfolio.st # !! # we change name here
    if (strip.history == TRUE) { # !! # but still attempt to reference old names in the loop
        for (symbol in names(orderbook[[portfolio.st]])) orderbook[[portfolio.st]][[symbol]] <- orderbook[[portfolio.st]][[symbol]][1, ] # keep potentially open orders
    }
    put.orderbook(cloned.portfolio.st, orderbook)
}

````

**Example:**

`````

library(quantstrat)
options(width = 250)
 
# INIT FABER
FinancialInstrument::currency('USD')
FinancialInstrument::stock(primary_id = "IBM", currency = "USD", multiplier = 1)    
# Sys.setenv(TZ = "UTC")
 
initPortf('faber', symbols="IBM")
initAcct('faber', portfolios='faber', initEq=100)
initOrders(portfolio='faber')
strategy("faber", store=TRUE)
add.indicator('faber', name = "rollapply", 
    arguments = list(data = quote(Cl(mktdata)), width=10, FUN=mean, fill = 0), label="SMA10")
add.signal('faber',name="sigCrossover",
    arguments = list(columns=c("Close","SMA10"),relationship="gte"),label="Cl.gt.SMA")
add.signal('faber',name="sigCrossover",
    arguments = list(columns=c("Close","SMA10"),relationship="lt"),label="Cl.lt.SMA")
add.rule('faber', name='ruleSignal', 
    arguments = list(sigcol="Cl.gt.SMA", sigval=TRUE, delay = 10, orderqty=500, 
             ordertype='market', orderside='long', pricemethod='market',TxnFees=-5), 
     type='enter', path.dep=TRUE)
 
add.rule('faber', name='ruleSignal', 
    arguments = list(sigcol="Cl.lt.SMA", sigval=TRUE, orderqty='all', ordertype='market', 
             orderside='long', pricemethod='market',TxnFees=-5),
     type='exit', path.dep=TRUE)
## END FABER
 
getSymbols(
    Symbols="IBM", 
    src="yahoo", 
    from=as.Date("2013-01-01"), 
    to=as.Date("2013-04-05"), 
    auto.assign = TRUE
)
 
applyStrategy(
    strategy='faber', 
    portfolios='faber'#,
    # rule.subset = "2014-12-23/2015-03-07"
)

quantstrat:::clone.orderbook('faber', 'faber.test', strip.history = TRUE)
all.equal(getOrderBook('faber')$faber$IBM, getOrderBook('faber.test')$faber.test$IBM)
[1] TRUE

`````
I've purposed the following patch:

